### PR TITLE
Automate README last update date

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -2,7 +2,7 @@
 Lista de canales de televisión, y radio, que se emiten en abierto por Internet. Especialmente enfocado a España, y a los principales canales Internacionales del mundo. Además la programación EPG está disponible e integrada automáticamente en los ficheros generados.
 
 ### Listas de reproducción
-*(Última actualización: 2025-09-04)*
+*(Última actualización: {{LAST_UPDATE}})*
 
 [Aquí](http://www.tdtchannels.com/lists/) podéis comprobar la última actualización de los canales, así como el listado de todos los disponibles. 
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import pathlib
+import subprocess
+
+def get_last_commit_date(repo: pathlib.Path) -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%cs"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+def main():
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    template_path = repo / "README.template.md"
+    output_path = repo / "README.md"
+    date = get_last_commit_date(repo)
+    content = template_path.read_text(encoding="utf-8")
+    content = content.replace("{{LAST_UPDATE}}", date)
+    output_path.write_text(content, encoding="utf-8")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README template with `{{LAST_UPDATE}}` marker
- introduce Python script to inject last commit date into README
- regenerate README using the new script

## Testing
- `python3 scripts/generate_readme.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68b986a1e8c48325ade1f1bd26d83a10